### PR TITLE
Make group operations explicit

### DIFF
--- a/lib/redshift_user.py
+++ b/lib/redshift_user.py
@@ -370,7 +370,7 @@ def main():
                     updated_user_data = get_user(cursor, user)
                     changed = update_password == "always" or current_user_data != updated_user_data
 
-            if group != '' and not group_exists(cursor, group):
+            if user == '' and group != '' and not group_exists(cursor, group):
                 group_add(cursor, group)
                 changed = True
                 group_added = True
@@ -391,7 +391,7 @@ def main():
                 changed = True
                 user_removed = True
 
-            if group != '' and group_exists(cursor, group):
+            if user == '' and group != '' and group_exists(cursor, group):
                 group_delete(cursor, group)
                 changed = True
                 group_removed = True


### PR DESCRIPTION
This change breaks existing playbooks, as it no longer "automagically" creates or deletes groups a user is member of. Now it requires you to explicitly create (and remove when no longer needed) the groups.

This removes the limitation that each group could only have one user, now you can have multiple users in a group.

Workflow now is:
1.  Create group
2.  Create user as a member of now existing group