### PR TITLE
make group creation / deletion explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,10 @@ available anymore. To still be able to update other user attributes, use `update
 
 **Assign an user to groups**
 
-*Note* This statement will create user and group (if not already existing) and assign the user to that group.
+*Note* Since version `0.3.0` a group MUST exist before you can assign users to it
 
-*Note* If a user is part of other groups, the user will be removed from all groups which are not specified.
-
-**Note** This module currently does *only* support a 1:1 relationship of user and group!
+*Note* If a user is part of other groups, the user will be removed from all groups which are not specified. This means
+also the module only supports n:1 relationships of users and groups!
 
 ```
 - redshift_user:
@@ -151,6 +150,7 @@ available anymore. To still be able to update other user attributes, use `update
 This is something you have to do manually at the moment!
 
 ```
+# remove user
 - redshift_user:
     login_host=some-redshift.cluster.eu-central-1.redshift.amazonaws.com 
     login_user=rs_master 
@@ -158,6 +158,14 @@ This is something you have to do manually at the moment!
     db=my_database
     user=new_rs_user
     password=passwF0rN3wRsUser
+    state=absent
+
+# remove group    
+- redshift_user:
+    login_host=some-redshift.cluster.eu-central-1.redshift.amazonaws.com 
+    login_user=rs_master 
+    login_password=123456Abcdef 
+    db=my_database
     group=new_rs_group
     state=absent
 ```
@@ -270,17 +278,17 @@ Not supported in this module version (yet)
  
 ## Developers FAQ
 
-*Why isn't this module using psycopg2 ?*
+**Why isn't this module using psycopg2 ?**
 
 The python psycopg2 package has `gcc` and `*-devel` as a dependency on machines based on the AWS Linux image. To
 not have this dependency, a python library without external dependencies was used.
 
-*Redshift vs PostgreSQL*
+**Redshift vs PostgreSQL**
 
 Redshift is not PostgreSQL, however we use a psql library for this module. This does the job, but at some points
 the library does not behave as expected, e.g. `cursor.rowcount` is not working.
 
-*Why is the result of a task always 'changed'?*
+**Why is the result of a task always 'changed'?**
 
 With release 0.2, the changed flag (also in dry-run) behaves like this:
 
@@ -288,12 +296,14 @@ With release 0.2, the changed flag (also in dry-run) behaves like this:
   existing and the new password
 * *always true* if `privs` are set
 
+**When using camelCase user or group names the module throws exceptions**
+
 NOTE: According to https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
 
 > Identifiers must consist of only UTF-8 printable characters. ASCII letters in standard and delimited identifiers are case-insensitive and are folded to lowercase in the database.
 
 So I would strongly recommend you to stick to lowercase identifiers unless you love to track down difficult to debug issues.
 
-*Contribute!*
+## Contribute!
 
 This module is in an early state. Feel free to contribute with bug reports or feature requests.

--- a/lib/redshift_user.py
+++ b/lib/redshift_user.py
@@ -370,7 +370,7 @@ def main():
                     updated_user_data = get_user(cursor, user)
                     changed = update_password == "always" or current_user_data != updated_user_data
 
-            if group != '' and not group_exists(cursor, group):
+            if user == '' and group != '' and not group_exists(cursor, group):
                 group_add(cursor, group)
                 changed = True
                 group_added = True
@@ -391,7 +391,7 @@ def main():
                 changed = True
                 user_removed = True
 
-            if group != '' and group_exists(cursor, group):
+            if user == '' and group != '' and group_exists(cursor, group):
                 group_delete(cursor, group)
                 changed = True
                 group_removed = True

--- a/test/integration/roles/test_changed_flag/tasks/test.yml
+++ b/test/integration/roles/test_changed_flag/tasks/test.yml
@@ -53,6 +53,36 @@
     msg: Unexpected state of changed flag
   when: "r_third_run.changed != false"
 
+- name: Create Testgroup
+  redshift_user:
+    login_host: "{{ redshift_host }}"
+    login_user: "{{ redshift_user }}"
+    login_password: "{{ redshift_password }}"
+    port: "{{ redshift_port }}"
+    db: "{{ redshift_db }}"
+    group: "{{ prefix_group }}group1"
+  register: r_fourth_run
+
+- name: Expect changed flag to be true because of created group
+  fail:
+    msg: Unexpected state of changed flag
+  when: "r_fourth_run.changed != true"
+
+- name: Run Create Testgroup again
+  redshift_user:
+    login_host: "{{ redshift_host }}"
+    login_user: "{{ redshift_user }}"
+    login_password: "{{ redshift_password }}"
+    port: "{{ redshift_port }}"
+    db: "{{ redshift_db }}"
+    group: "{{ prefix_group }}group1"
+  register: r_fifth_run
+
+- name: Expect changed flag to be false because nothing has changed
+  fail:
+    msg: Unexpected state of changed flag
+  when: "r_fifth_run.changed != false"
+
 - name: Assign Test User To Group
   redshift_user:
     login_host: "{{ redshift_host }}"
@@ -65,12 +95,12 @@
     password: "passwF0rN3wRsUser"
     update_password: "on_create"
     conn_limit: 10
-  register: r_fourth_run
+  register: r_sixth_run
 
-- name: Expect changed flag to be true because group was created and assigned
+- name: Expect changed flag to be true because group was assigned
   fail:
     msg: Unexpected state of changed flag
-  when: "r_fourth_run.changed != true"
+  when: "r_sixth_run.changed != true"
 
 - name: Update User With Same Settings Again
   redshift_user:
@@ -84,9 +114,9 @@
     password: "passwF0rN3wRsUser"
     update_password: "on_create"
     conn_limit: 10
-  register: r_fifth_run
+  register: r_seventh_run
 
 - name: Expect changed flag to be false because nothing was changed
   fail:
     msg: Unexpected state of changed flag
-  when: "r_fifth_run.changed != false"
+  when: "r_seventh_run.changed != false"

--- a/test/integration/roles/test_create_user_group/tasks/execute.yml
+++ b/test/integration/roles/test_create_user_group/tasks/execute.yml
@@ -1,6 +1,15 @@
 ---
 
-- name: Create Testuser And Group
+- name: Create Testgroup
+  redshift_user:
+    login_host: "{{ redshift_host }}"
+    login_user: "{{ redshift_user }}"
+    login_password: "{{ redshift_password }}"
+    port: "{{ redshift_port }}"
+    db: "{{ redshift_db }}"
+    group: "{{ prefix_group }}group1"
+
+- name: Create Testuser and assign to group
   redshift_user:
     login_host: "{{ redshift_host }}"
     login_user: "{{ redshift_user }}"

--- a/test/integration/roles/test_create_user_group_revoke/tasks/test.yml
+++ b/test/integration/roles/test_create_user_group_revoke/tasks/test.yml
@@ -1,6 +1,15 @@
 ---
 
-- name: Create Testuser And Group
+- name: Create Testgroup
+  redshift_user:
+    login_host: "{{ redshift_host }}"
+    login_user: "{{ redshift_user }}"
+    login_password: "{{ redshift_password }}"
+    port: "{{ redshift_port }}"
+    db: "{{ redshift_db }}"
+    group: "{{ prefix_group }}group1"
+
+- name: Create Testuser and assign to group
   redshift_user:
     login_host: "{{ redshift_host }}"
     login_user: "{{ redshift_user }}"

--- a/test/integration/roles/test_delete_user_group/tasks/execute.yml
+++ b/test/integration/roles/test_delete_user_group/tasks/execute.yml
@@ -1,6 +1,15 @@
 ---
 
-- name: Create Testuser And Group
+- name: Create Testgroup
+  redshift_user:
+    login_host: "{{ redshift_host }}"
+    login_user: "{{ redshift_user }}"
+    login_password: "{{ redshift_password }}"
+    port: "{{ redshift_port }}"
+    db: "{{ redshift_db }}"
+    group: "{{ prefix_group }}group1"
+
+- name: Create Testuser and assign to group
   redshift_user:
     login_host: "{{ redshift_host }}"
     login_user: "{{ redshift_user }}"
@@ -12,7 +21,7 @@
     password: "passwF0rN3wRsUser"
     conn_limit: "10"
 
-- name: Remove Testuser And Group
+- name: Remove Testuser
   redshift_user:
     login_host: "{{ redshift_host }}"
     login_user: "{{ redshift_user }}"
@@ -20,5 +29,15 @@
     port: "{{ redshift_port }}"
     db: "{{ redshift_db }}"
     user: "{{ prefix_user }}user1"
+    group: "{{ prefix_group }}group1"
+    state: 'absent'
+
+- name: Remove Testgroup
+  redshift_user:
+    login_host: "{{ redshift_host }}"
+    login_user: "{{ redshift_user }}"
+    login_password: "{{ redshift_password }}"
+    port: "{{ redshift_port }}"
+    db: "{{ redshift_db }}"
     group: "{{ prefix_group }}group1"
     state: 'absent'


### PR DESCRIPTION
Includes PR #13 from @jnerin

This PR removes the implicit creation / deletion of groups when used together with the `user` attribute, as this behaviour turned out to be confusing in daily usage. A group has to be created explicit from now on as described in the README.